### PR TITLE
Disabled the drop pin

### DIFF
--- a/src/Widget.js
+++ b/src/Widget.js
@@ -189,7 +189,7 @@ require(REQUIRE_CONFIG, [], function () {
                     this._bindViewerDependantEventHandlers();
                     this._setButtonVisibilityInApi();
                     this._handleImageChange();
-                    this._drawDraggableMarker();
+                    // this._drawDraggableMarker();
 
                     if(this.config.navigation === false){
                         this._hideNavigation();


### PR DESCRIPTION
We are temporarily disabeling the drop pin until we have fixed it. 
This means that is won't be there in the next release (18.2 with the 18.15 api), but it will be back later.