### PR TITLE
STREET-5197: styling fixes for Dart Theme - based on 22.17

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -315,7 +315,7 @@ label {
 }
 
 .dart-panel #panoramaViewerDiv #cmt .measurement-navbar *,
-.dart-panel #panoramaViewerDiv #cmt .btn-viewer-icn:not(:hover) .glyphicon,
+.dart-panel #panoramaViewerDiv #cmt .btn-viewer-icn:not(:hover):not(:focus) .glyphicon,
 .dart-panel .jimu-widget-frame.jimu-container .cmt .cmtViewerPanel .panel-body .btn-secondary-right span,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar  .btn.btn-default *,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .cmt-navbar.measurement-navbar *,

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -282,8 +282,14 @@
 .esriAttributeInspector .atiButtons .saveButton {
     margin: 0 5px 0 0 ;
 }
-/* dashboard theme fixes*/
 
+#cmt .btn-container {
+    padding: 0;
+    margin-inline: unset;
+    width: unset;
+}
+
+/* dashboard theme fixes*/
 label {
     color: #545454;
 }
@@ -298,7 +304,8 @@ label {
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar .measurement-dropdown:hover .btn.btn-default,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar .measurement-dropdown:hover .btn.btn-default *,
 .dart-panel #panoramaViewerDiv #cmt .measurement-navbar button:hover,
-.dart-panel #panoramaViewerDiv #cmt .measurement-navbar button:hover .glyphicon
+.dart-panel #panoramaViewerDiv #cmt .measurement-navbar button:hover .glyphicon,
+.dart-panel #panoramaViewerDiv #cmt .imageControls button .glyphicon
 {
     color: white !important;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -282,20 +282,28 @@
 .esriAttributeInspector .atiButtons .saveButton {
     margin: 0 5px 0 0 ;
 }
+/* dashboard theme fixes*/
 
-.dart-panel .jimu-widget-frame.jimu-container .cmt *,
+label {
+    color: #545454;
+}
+
+/*!* dart theme fixes *!*/
 .dart-panel .jimu-widget-frame.jimu-container .cmt .cmtViewerPanel .panel-body .btn-secondary-right:hover span,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt.viewer .cmtNavBarPanel .nav-stacked>li a,
-.dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .panel-default .panel-heading,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .modal  .btn.btn-default *,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar .btn.btn-default:hover *,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar.expandable-navbar .btn.btn-default:focus *,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar .measurement-dropdown .dropdown-menu li:hover a>span,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar .measurement-dropdown:hover .btn.btn-default,
-.dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar .measurement-dropdown:hover .btn.btn-default *{
+.dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar .measurement-dropdown:hover .btn.btn-default *,
+.dart-panel #panoramaViewerDiv #cmt .measurement-navbar button:hover,
+.dart-panel #panoramaViewerDiv #cmt .measurement-navbar button:hover .glyphicon
+{
     color: white !important;
 }
 
+.dart-panel #panoramaViewerDiv #cmt .nav-tabs > li a,
 .dart-panel .jimu-widget-frame.jimu-container .cmt .cmtViewerPanel .panel-body .slider-tick-label,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .dropdown-menu>li>a,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .cmtImageInformationPanel .tab-content *,
@@ -306,6 +314,8 @@
     color: #005293 !important;
 }
 
+.dart-panel #panoramaViewerDiv #cmt .measurement-navbar *,
+.dart-panel #panoramaViewerDiv #cmt .btn-viewer-icn:not(:hover) .glyphicon,
 .dart-panel .jimu-widget-frame.jimu-container .cmt .cmtViewerPanel .panel-body .btn-secondary-right span,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar  .btn.btn-default *,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .cmt-navbar.measurement-navbar *,
@@ -322,14 +332,23 @@
     color: #bcbdbc !important;
 }
 
-.dart-panel .jimu-widget-frame.jimu-container .cmt .cmtViewerPanel .panel-body label.control-label,
-.dart-panel .jimu-widget-frame.jimu-container .cmt .layerpanel .checkbox span{
+.dart-panel #cmt .measurement-select-modal .btn-modal__wrapper,
+.dart-panel #cmt .share-modal .btn-modal__wrapper,
+.dart-panel #panoramaViewerDiv #cmt label,
+.dart-panel #measurementPanel *:not(button),
+.dart-panel #measurementPanel .close-button,
+.dart-panel #cmt .sidebar-panel-container *,
+.dart-panel #cmt .cmtViewerPanel .card-body *,
+.dart-panel #cmt .layerpanel .checkbox span {
     color: #666 !important;
 }
+
 .dart-panel .jimu-widget-frame.jimu-container .timetravel .travelDate span {
     color: #2c3e50 !important;
 }
 
+.dart-panel #panoramaViewerDiv .nav-link.active,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .measurement-floating-panel .warning span {
     color: #ec7a08 !important
 }
+


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/101108163/200855014-9e1e8cb9-1bbe-41c7-95ea-4fade502874d.png)


Visual fixes for the Dart theme. Locally the measurements didn't work, so couldn't test any changes