### PR TITLE
STREET-5377 fixes for widget | Grand Nancy implementation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -368,14 +368,19 @@ label {
 th{
     font-weight: bold;
 }
-
-.cmt .table-wrap th, .cmt .table-wrap td{
+/* fixing object info table*/
+#cmt .table-wrap th, #cmt .table-wrap td{
     max-width: 250px;
     word-break: normal !important;
 }
 
-.cmt .viewer .cmtNavBarPanel .attributeinfopanel .panel-heading{
+#cmt .viewer .cmtNavBarPanel .attributeinfopanel .panel-heading{
     overflow: auto;
+}
+
+#cmt .viewer .cmtNavBarPanel .attributeinfopanel .panel-heading .card-title{
+    display: flex;
+    margin-bottom: 0px;
 }
 
 /* fixed size for navbar icons */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -53,6 +53,10 @@
     font-size: 24px;
 }
 
+.cmt-widget #side-panel-close-button:hover{
+    cursor: pointer;
+}
+
 .cmt-widget #zoom-warning {
     position: absolute;
     top: 50%;
@@ -161,6 +165,11 @@
     border: 1px solid #0054a6;
     border-radius: 50%;
 }
+
+.cmt-widget button.measurement-button.glyphicon:hover{
+    cursor: pointer;
+}
+
 .cmt-widget button.measurement-button.glyphicon:disabled {
     opacity: 0.3;
     cursor: default;
@@ -371,7 +380,7 @@ th{
 
 /* fixed size for navbar icons */
 .cmt-widget #cmt .btn-viewer-icn .glyphicon {
-    font-size: 24px;
+    font-size: 22px;
 }
 
 /* show active tabs | reset opacity to 1 */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -320,7 +320,7 @@ label {
 
 .dart-panel #panoramaViewerDiv .nav-link.active,
 .dart-panel #panoramaViewerDiv #cmt .measurement-navbar *,
-.dart-panel #panoramaViewerDiv #cmt .btn-viewer-icn:not(:hover):not(.active-panel) .glyphicon,
+.dart-panel #panoramaViewerDiv #cmt .btn-viewer-icn:not(:hover):not(.active-panel):not(:focus) .glyphicon,
 .dart-panel .jimu-widget-frame.jimu-container .cmt .cmtViewerPanel .panel-body .btn-secondary-right span,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .navbar  .btn.btn-default *,
 .dart-panel .jimu-widget-frame.jimu-container #panoramaViewerDiv .cmt .cmt-navbar.measurement-navbar *,
@@ -367,4 +367,14 @@ th{
 
 .cmt .viewer .cmtNavBarPanel .attributeinfopanel .panel-heading{
     overflow: auto;
+}
+
+/* fixed size for navbar icons */
+.cmt-widget #cmt .btn-viewer-icn .glyphicon {
+    font-size: 24px;
+}
+
+/* show active tabs | reset opacity to 1 */
+.cmt-widget .show {
+    opacity: 1;
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/101108163/209106924-b3298a28-2e2d-4f51-8f5b-91dbea9d8a0c.png)


- Icons should be larger (although other text is still small, because of their own small font size)
- Tab content is visible again