### PR TITLE
WIDGET: dashboard theme - fix for white text color in measurements si…

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -270,13 +270,19 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    background-color: rgba(65,65,65,.75);
-    min-height: 33px;
+
     pointer-events: none;
     color: white;
-    padding-inline: 8%;
 }
 
+.cmt-widget .inner-address-bar {
+    display: flex;
+    padding-inline: 8%;
+    min-height: 33px;
+    justify-content: center;
+    align-items: center;
+    background-color: rgba(65, 65, 65, .75);
+}
 
 .esriAttributeInspector .atiButtons .atiDeleteButton {
     width: auto;
@@ -291,6 +297,11 @@
     padding: 0;
     margin-inline: unset;
     width: unset;
+}
+
+/* sidebar color fix */
+.cmt-widget .sidebar-container{
+    color: #545454;
 }
 
 /* dashboard theme fixes*/
@@ -385,7 +396,7 @@ th{
 
 /* fixed size for navbar icons */
 .cmt-widget #cmt .btn-viewer-icn .glyphicon {
-    font-size: 22px;
+    font-size: 24px;
 }
 
 /* show active tabs | reset opacity to 1 */


### PR DESCRIPTION
WIDGET: dashboard theme - fix for white text color in measurements side panel
Tested with API 23.3

![image](https://user-images.githubusercontent.com/101108163/225314365-715d3dc8-1e7c-4ec4-a23d-ba28255caa39.png)

Also added a small fix for the address bar: it now collapses visually when there's no address to show
